### PR TITLE
Refactor timeline editing logic and centralize state management in ViewModel

### DIFF
--- a/lib/viewmodels/editor/editor_layout_viewmodel.dart
+++ b/lib/viewmodels/editor/editor_layout_viewmodel.dart
@@ -264,7 +264,7 @@ class EditorLayoutViewModel { // Remove LoggerExtension
     return DockingItem(
       id: 'timeline',
       name: 'Timeline',
-      widget: const Timeline(), // Assumes Timeline takes no args
+      widget: const Timeline(), // Timeline no longer takes these parameters
     );
   }
 

--- a/lib/viewmodels/editor_viewmodel.dart
+++ b/lib/viewmodels/editor_viewmodel.dart
@@ -34,6 +34,10 @@ class EditorViewModel {
   // Notifier for the video URL currently under the playhead
   final ValueNotifier<String?> currentPreviewVideoUrlNotifier = ValueNotifier<String?>(null);
 
+  // State for snapping and aspect ratio lock (moved from PreviewPanel)
+  final ValueNotifier<bool> snappingEnabledNotifier = ValueNotifier<bool>(true);
+  final ValueNotifier<bool> aspectRatioLockedNotifier = ValueNotifier<bool>(true);
+
   // Listener for layout changes
   VoidCallback? _layoutListener;
   
@@ -79,6 +83,8 @@ class EditorViewModel {
     isInspectorVisibleNotifier.dispose();
     isPreviewVisibleNotifier.dispose();
     currentPreviewVideoUrlNotifier.dispose(); // Dispose new notifier
+    snappingEnabledNotifier.dispose(); // Dispose snapping notifier
+    aspectRatioLockedNotifier.dispose(); // Dispose aspect ratio notifier
     
     // Remove timeline listeners
     if (_timelineFrameListener != null) {
@@ -100,8 +106,21 @@ class EditorViewModel {
     layoutManager.dispose();
     logInfo(_logTag, "EditorViewModel disposed.");
   }
-
+  
   // --- Actions ---
+  
+  /// Toggles the snapping feature state.
+  void toggleSnapping() {
+    snappingEnabledNotifier.value = !snappingEnabledNotifier.value;
+    logInfo(_logTag, "Snapping Toggled: ${snappingEnabledNotifier.value}");
+  }
+  
+  /// Toggles the aspect ratio lock feature state.
+  void toggleAspectRatioLock() {
+    aspectRatioLockedNotifier.value = !aspectRatioLockedNotifier.value;
+    logInfo(_logTag, "Aspect Ratio Lock Toggled: ${aspectRatioLockedNotifier.value}");
+  }
+  
   // Toggle timeline visibility using generic method
   void toggleTimeline() => layoutManager.toggleTimeline();
   

--- a/lib/views/widgets/timeline/components/timeline_controls.dart
+++ b/lib/views/widgets/timeline/components/timeline_controls.dart
@@ -6,6 +6,9 @@ import 'package:flipedit/models/enums/edit_mode.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 /// Controls widget for the timeline including playback controls and zoom
+import 'package:flipedit/viewmodels/editor_viewmodel.dart'; // Import EditorViewModel
+
+/// Controls widget for the timeline including playback controls and zoom
 class TimelineControls extends StatelessWidget with WatchItMixin {
   const TimelineControls({super.key});
 
@@ -14,12 +17,17 @@ class TimelineControls extends StatelessWidget with WatchItMixin {
     final theme = FluentTheme.of(context);
     final controlsContentColor = theme.resources.textFillColorPrimary;
     final timelineViewModel = di<TimelineViewModel>();
+    final editorViewModel = di<EditorViewModel>(); // Inject EditorViewModel
 
     // Watch basic values
     final isPlaying = watchValue((TimelineViewModel vm) => vm.isPlayingNotifier);
     final totalFrames = watchValue((TimelineViewModel vm) => vm.totalFramesNotifier);
     final zoom = watchValue((TimelineViewModel vm) => vm.zoomNotifier);
     final isPlayheadLocked = watchValue((TimelineViewModel vm) => vm.isPlayheadLockedNotifier); // Watch lock state
+
+    // Watch snapping and aspect ratio lock states from EditorViewModel
+    final snappingEnabled = watchValue((EditorViewModel vm) => vm.snappingEnabledNotifier);
+    final aspectRatioLocked = watchValue((EditorViewModel vm) => vm.aspectRatioLockedNotifier);
 
     // Edit mode toolbar
     final currentMode = watchValue((TimelineViewModel vm) => vm.currentEditMode);
@@ -34,74 +42,6 @@ class TimelineControls extends StatelessWidget with WatchItMixin {
           child: IconButton(
             icon: const Icon(HugeIcons.strokeRoundedCursor01, size: 16),
             onPressed: () => timelineViewModel.setEditMode(EditMode.select),
-            style: ButtonStyle(
-              padding: WidgetStateProperty.all(const EdgeInsets.all(4)),
-              foregroundColor: WidgetStateProperty.all(controlsContentColor),
-            ),
-          ),
-        ),
-      ),
-      Tooltip(
-        message: 'Ripple Trim',
-        child: Container(
-          decoration: BoxDecoration(
-            color: currentMode == EditMode.rippleTrim ? theme.accentColor.lightest : Colors.transparent,
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: IconButton(
-            icon: const Icon(HugeIcons.strokeRoundedCrop, size: 16),
-            onPressed: () => timelineViewModel.setEditMode(EditMode.rippleTrim),
-            style: ButtonStyle(
-              padding: WidgetStateProperty.all(const EdgeInsets.all(4)),
-              foregroundColor: WidgetStateProperty.all(controlsContentColor),
-            ),
-          ),
-        ),
-      ),
-      Tooltip(
-        message: 'Roll',
-        child: Container(
-          decoration: BoxDecoration(
-            color: currentMode == EditMode.rollEdit ? theme.accentColor.lightest : Colors.transparent,
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: IconButton(
-            icon: const Icon(HugeIcons.strokeRoundedArrowHorizontal, size: 16),
-            onPressed: () => timelineViewModel.setEditMode(EditMode.rollEdit),
-            style: ButtonStyle(
-              padding: WidgetStateProperty.all(const EdgeInsets.all(4)),
-              foregroundColor: WidgetStateProperty.all(controlsContentColor),
-            ),
-          ),
-        ),
-      ),
-      Tooltip(
-        message: 'Slip',
-        child: Container(
-          decoration: BoxDecoration(
-            color: currentMode == EditMode.slip ? theme.accentColor.lightest : Colors.transparent,
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: IconButton(
-            icon: const Icon(HugeIcons.strokeRoundedCursorMove01, size: 16),
-            onPressed: () => timelineViewModel.setEditMode(EditMode.slip),
-            style: ButtonStyle(
-              padding: WidgetStateProperty.all(const EdgeInsets.all(4)),
-              foregroundColor: WidgetStateProperty.all(controlsContentColor),
-            ),
-          ),
-        ),
-      ),
-      Tooltip(
-        message: 'Slide',
-        child: Container(
-          decoration: BoxDecoration(
-            color: currentMode == EditMode.slide ? theme.accentColor.lightest : Colors.transparent,
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: IconButton(
-            icon: const Icon(HugeIcons.strokeRoundedArrowHorizontal, size: 16),
-            onPressed: () => timelineViewModel.setEditMode(EditMode.slide),
             style: ButtonStyle(
               padding: WidgetStateProperty.all(const EdgeInsets.all(4)),
               foregroundColor: WidgetStateProperty.all(controlsContentColor),
@@ -195,11 +135,57 @@ class TimelineControls extends StatelessWidget with WatchItMixin {
             ),
           ),
 
-         const SizedBox(width: 16), // Spacing after playback controls
+          const SizedBox(width: 16), // Spacing after playback controls
 
-         ...modeButtons, // Keep the mode buttons
+          ...modeButtons, // Keep the mode buttons
 
-         const SizedBox(width: 16), // Spacing after mode buttons (if any)
+          const SizedBox(width: 16), // Spacing after mode buttons
+
+          Tooltip(
+            message: 'Enable Snapping',
+            child: Container(
+              decoration: BoxDecoration(
+                color: snappingEnabled ? theme.accentColor.lightest : Colors.transparent, // Use watched state
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: IconButton(
+                icon: Icon(
+                  HugeIcons.strokeRoundedMagnet,
+                  size: 16,
+                  color: controlsContentColor,
+                ),
+                onPressed: editorViewModel.toggleSnapping, // Call ViewModel method
+                style: ButtonStyle(
+                  padding: WidgetStateProperty.all(const EdgeInsets.all(4)),
+                  foregroundColor: WidgetStateProperty.all(controlsContentColor),
+                ),
+              ),
+            ),
+          ),
+
+          Tooltip(
+            message: aspectRatioLocked ? 'Unlock Aspect Ratio (Aspect Ratio Locked)' : 'Lock Aspect Ratio', // Use watched state for message
+            child: Container(
+              decoration: BoxDecoration(
+                color: aspectRatioLocked ? theme.accentColor.lightest : Colors.transparent, // Use watched state
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: IconButton(
+                icon: Icon(
+                  aspectRatioLocked ? HugeIcons.strokeRoundedTouchLocked01 : HugeIcons.strokeRoundedTouch01, // Use suggested touch icons
+                  size: 16,
+                  color: controlsContentColor,
+                ),
+                onPressed: editorViewModel.toggleAspectRatioLock, // Call ViewModel method
+                style: ButtonStyle(
+                  padding: WidgetStateProperty.all(const EdgeInsets.all(4)),
+                  foregroundColor: WidgetStateProperty.all(controlsContentColor),
+                ),
+              ),
+            ),
+          ),
+
+          const SizedBox(width: 16), // Spacing after new buttons
         ],
       ),
     );

--- a/lib/views/widgets/timeline/timeline.dart
+++ b/lib/views/widgets/timeline/timeline.dart
@@ -14,7 +14,11 @@ import 'package:flipedit/views/widgets/timeline/components/timeline_playhead.dar
 /// Main timeline widget that shows clips and tracks
 /// Similar to the timeline in video editors like Premiere Pro or Final Cut
 class Timeline extends StatefulWidget with WatchItStatefulWidgetMixin { // Mixin moved here
-  const Timeline({super.key});
+  // Parameters for snapping and aspect ratio lock removed - now handled by EditorViewModel
+
+  const Timeline({
+    super.key,
+  });
 
   @override
   State<Timeline> createState() => _TimelineState();
@@ -111,8 +115,8 @@ class _TimelineState extends State<Timeline> { // Mixin removed here
       color: theme.resources.cardBackgroundFillColorDefault,
       child: Column(
         children: [
-          // Now uses WatchingWidget, no params needed
-          const TimelineControls(),
+          // TimelineControls no longer requires snapping/aspect ratio parameters
+          TimelineControls(),
 
           // Unified Timeline Content Area
           Expanded(

--- a/test/views/widgets/timeline/timeline_test.dart
+++ b/test/views/widgets/timeline/timeline_test.dart
@@ -27,6 +27,9 @@ void main() {
   late ValueNotifier<double> testTrackLabelWidthNotifier;
   late ScrollController testScrollController;
   late ValueNotifier<List<project_db.Track>> testTracksNotifier;
+  
+  // Define a static empty callback for test purposes
+  void _emptyCallback() {}
 
 
   setUp(() {
@@ -71,7 +74,7 @@ void main() {
     testWidgets('should render Timeline widget correctly', (WidgetTester tester) async {
       await tester.pumpWidget(
         FluentApp(
-          home: const Timeline(),
+          home: const Timeline(), // Remove parameters
         ),
       );
 
@@ -83,7 +86,7 @@ void main() {
       // For now, a placeholder test to ensure rendering
       await tester.pumpWidget(
         FluentApp(
-          home: const Timeline(),
+          home: const Timeline(), // Remove parameters
         ),
       );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added snapping and aspect ratio lock toggles to the timeline controls, allowing users to enable or disable these editing aids directly from the interface.
  - Introduced clip selection in the preview panel, enabling users to select clips for resizing or moving with visible handles.

- **Improvements**
  - Snapping and aspect ratio lock states are now managed centrally for more consistent behavior across the timeline and preview panel.
  - Enhanced snapping logic to distinguish between dragging and resizing for more intuitive editing.
  - Improved robustness and feedback when adding or updating clips on the timeline.

- **Bug Fixes**
  - Improved error handling when clips are missing during timeline operations to prevent unexpected failures.

- **Style/Refactor**
  - Cleaned up widget parameters and centralized state management for snapping and aspect ratio lock.
  - Removed playback controls from the preview panel for a cleaner editing interface.

- **Documentation**
  - Updated comments for clarity in the editor layout view model.

- **Tests**
  - Updated timeline widget tests to match the new constructor signature and state management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->